### PR TITLE
[WIP] Bluemixにデプロイするための設定

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: bin/hubot -a campfire

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,6 @@
+applications:
+- buildpack: https://github.com/jthomas/nodejs-v4-buildpack.git
+  command: ./bin/hubot --adapter slack
+  path: .
+  instances: 1
+  memory: 256M


### PR DESCRIPTION
## 概要

Bluemix（IBMのPaaS）にHubotをデプロイするための設定を行う。
## Hubotのドキュメント

[Instructions for deploying hubot to IBM Bluemix](https://github.com/github/hubot/blob/master/docs/deploying/bluemix.md)
